### PR TITLE
The printing line 102 fails with undefined local variable or method 'wait_time' (NameError)

### DIFF
--- a/beetlejuice.rb
+++ b/beetlejuice.rb
@@ -99,7 +99,7 @@ class Beetlejuice
     puts
     puts 'Bugsnag::Api::RateLimitExceeded while getting events list'
     wait_time_total = 60
-    puts "Waiting #{wait_time} seconds"
+    puts "Waiting #{wait_time_total} seconds"
 
     progress_bar_length = 30
     wait_time = wait_time_total / progress_bar_length


### PR DESCRIPTION
Hi!

Just a quick fix for what I guess is a typo. The RateLimit handling otherwise fails with the following trace:

<img width="1024" alt="Screenshot 2021-04-19 at 08 59 34" src="https://user-images.githubusercontent.com/7113624/115200861-f6eb1d00-a0f4-11eb-8cb5-2f599811e600.png">

Thanks for the handy tool!